### PR TITLE
Iss31

### DIFF
--- a/src/meshflow/utility/templating.py
+++ b/src/meshflow/utility/templating.py
@@ -142,6 +142,8 @@ def render_class_template(
     # create a dictionary for GRU blocks
     gru_block = {"vars": []}
 
+    print('class_grus: ', class_grus)
+
     for gru, params in class_grus.items():
         d = {}
         for param, param_value in params.items():
@@ -151,11 +153,22 @@ def render_class_template(
             param_line = gru_lines[param]
             param_type = gru_types[param]
 
+            # add the line number as a key to the parameter type dictionary
+            # if the `param_type` key does not exist, add it first
+            if param_type not in d.keys():
+                d[param_type] = {}
+
+            # ensure the line key exists
+            if f'line{param_line}' not in d[param_type].keys():
+                d[param_type][f'line{param_line}'] = {}  # ensure the key exists
+
             if param_type in d.keys():
-                d[param_type].update({f'line{param_line}': {param: param_value}})
+                d[param_type][f'line{param_line}'].update({param: param_value})
             else:
-                d[param_type] = {f'line{param_line}': {param: param_value}}
+                d[param_type][f'line{param_line}'] = {param: param_value}
         gru_block['vars'].append(d)
+
+    print('before: ', gru_block)
 
     # deep update GRU blocks
     for block in gru_block['vars']:
@@ -166,6 +179,8 @@ def render_class_template(
 
         # update the block dictionary
         populating_list.append(it)
+
+    print('after: ', gru_block)
 
     # update the class parameters with the populated list
     # gru_block['vars'] is populated based on the assumption that

--- a/src/meshflow/utility/templating.py
+++ b/src/meshflow/utility/templating.py
@@ -142,7 +142,6 @@ def render_class_template(
     # create a dictionary for GRU blocks
     gru_block = {"vars": []}
 
-    print('class_grus: ', class_grus)
 
     for gru, params in class_grus.items():
         d = {}
@@ -168,8 +167,6 @@ def render_class_template(
                 d[param_type][f'line{param_line}'] = {param: param_value}
         gru_block['vars'].append(d)
 
-    print('before: ', gru_block)
-
     # deep update GRU blocks
     for block in gru_block['vars']:
         new_data = copy.deepcopy(data)
@@ -179,8 +176,6 @@ def render_class_template(
 
         # update the block dictionary
         populating_list.append(it)
-
-    print('after: ', gru_block)
 
     # update the class parameters with the populated list
     # gru_block['vars'] is populated based on the assumption that


### PR DESCRIPTION
Fixing #31

This pull request updates the way GRU parameter types and their line numbers are organized within the `render_class_template` function in `src/meshflow/utility/templating.py`. The changes ensure that the data structure for GRU parameters is more robust and avoids overwriting existing entries when multiple parameters share the same type and line number.

Improvements to GRU parameter organization:

* The code now checks and initializes nested dictionaries for each parameter type and line number before updating, ensuring that parameters with the same type and line are grouped correctly without overwriting each other.
* Minor formatting adjustment: added a blank line for readability.